### PR TITLE
docs: Clean up parameter documentation

### DIFF
--- a/lib/psiprocess.h
+++ b/lib/psiprocess.h
@@ -44,7 +44,7 @@ public:
     * A copy constructor.
     * Mainly used by STL container classes.
     *
-    * @param d The object to be used as initializer.
+    * @param p The object to be used as initializer.
     */
     PsiProcess(const PsiProcess &p);
 
@@ -91,7 +91,7 @@ public:
     * Assignment operator
     * Mainly used by STL container classes.
     *
-    * @param e The new value to assign.
+    * @param p The new value to assign.
     *
     * @returns The modified object.
     */

--- a/lib/rclip.h
+++ b/lib/rclip.h
@@ -164,7 +164,6 @@ protected:
     * to E_PSI_FILE_DISC.
     *
     * @param cc The command to execute on the remote side.
-    * @param data Additional data for this command.
     *
     * @returns true on success, false on failure.
     */


### PR DESCRIPTION
Looks like this was some copy-and-paste fun.