### PR TITLE
fix: Use local includes for local headers

### DIFF
--- a/lib/Enum.h
+++ b/lib/Enum.h
@@ -26,8 +26,7 @@
 #include <map>
 #include <string>
 
-#include <plpintl.h>
-#include <assert.h>
+#include "plpintl.h"
 
 /**
  * the Base for the Enum template.
@@ -131,7 +130,7 @@ protected:
  * and more readable, an ENUM_DEFINITION() macro is provided.
  *
  * FIXME: At the moment enumeration strings don't get translated by gettext
- * 
+ *
  * @see #ENUM_DEFINITION
  * @author Henner Zeller
  */
@@ -296,10 +295,10 @@ template<typename E> typename Enum<E>::sdata Enum<E>::staticData;
  *
  * @author Henner Zeller
  */
-/**								
-  * The definition of the static variable holding the static	
-  * data for this Enumeration wrapper.				
-  */								
+/**
+  * The definition of the static variable holding the static
+  * data for this Enumeration wrapper.
+  */
 #define ENUM_DEFINITION_BEGIN(EnumName, initWith)			\
 /**								\
   * actual definition of the constructor for the static data.	\

--- a/lib/plpdirent.h
+++ b/lib/plpdirent.h
@@ -24,8 +24,8 @@
 #include <string>
 #include <cstring>
 
-#include <psitime.h>
-#include <rfsv.h>
+#include "psitime.h"
+#include "rfsv.h"
 
 /**
  * A class, representing the UIDs of a file on the Psion.

--- a/lib/psibitmap.h
+++ b/lib/psibitmap.h
@@ -21,7 +21,7 @@
 #ifndef _PSIBITMAP_H_
 #define _PSIBITMAP_H_
 
-#include <bufferstore.h>
+#include "bufferstore.h"
 
 /**
  * This function is used by encodeBitmap for retrieving image data.

--- a/lib/psitime.h
+++ b/lib/psitime.h
@@ -30,7 +30,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 
-#include <plpintl.h>
+#include "plpintl.h"
 
 /**
  * Holds a Psion time value.

--- a/lib/rclip.h
+++ b/lib/rclip.h
@@ -20,8 +20,8 @@
 #ifndef _RCLIP_H_
 #define _RCLIP_H_
 
-#include <rfsv.h>
-#include <Enum.h>
+#include "rfsv.h"
+#include "Enum.h"
 
 class ppsocket;
 class bufferStore;

--- a/lib/rfsv.h
+++ b/lib/rfsv.h
@@ -24,9 +24,9 @@
 #include <deque>
 #include <string>
 
-#include <Enum.h>
-#include <plpdirent.h>
-#include <bufferstore.h>
+#include "Enum.h"
+#include "plpdirent.h"
+#include "bufferstore.h"
 
 typedef std::deque<class PlpDirent> PlpDir;
 

--- a/lib/rfsv16.h
+++ b/lib/rfsv16.h
@@ -21,7 +21,7 @@
 #ifndef _RFSV16_H_
 #define _RFSV16_H_
 
-#include <rfsv.h>
+#include "rfsv.h"
 
 class rfsvfactory;
 

--- a/lib/rfsv32.h
+++ b/lib/rfsv32.h
@@ -22,8 +22,8 @@
 #ifndef _RFSV32_H_
 #define _RFSV32_H_
 
-#include <rfsv.h>
-#include <plpdirent.h>
+#include "rfsv.h"
+#include "plpdirent.h"
 
 class rfsvfactory;
 

--- a/lib/rfsvfactory.h
+++ b/lib/rfsvfactory.h
@@ -22,7 +22,7 @@
 #ifndef _RFSVFACTORY_H_
 #define _RFSVFACTORY_H_
 
-#include <rfsv.h>
+#include "rfsv.h"
 
 class ppsocket;
 

--- a/lib/rpcs.h
+++ b/lib/rpcs.h
@@ -20,10 +20,10 @@
 #ifndef _RPCS_H_
 #define _RPCS_H_
 
-#include <psitime.h>
-#include <psiprocess.h>
-#include <rfsv.h>
-#include <Enum.h>
+#include "psitime.h"
+#include "psiprocess.h"
+#include "rfsv.h"
+#include "Enum.h"
 
 #include <vector>
 

--- a/lib/rpcs16.h
+++ b/lib/rpcs16.h
@@ -21,7 +21,7 @@
 #ifndef _RPCS16_H_
 #define _RPCS16_H_
 
-#include <rpcs.h>
+#include "rpcs.h"
 
 class ppsocket;
 class bufferStore;

--- a/lib/rpcs32.h
+++ b/lib/rpcs32.h
@@ -21,7 +21,7 @@
 #ifndef _RPCS32_H_
 #define _RPCS32_H_
 
-#include <rpcs.h>
+#include "rpcs.h"
 
 class ppsocket;
 class rpcsfactory;

--- a/lib/rpcsfactory.h
+++ b/lib/rpcsfactory.h
@@ -21,7 +21,7 @@
 #ifndef _RPCSFACTORY_H_
 #define _RPCSFACTORY_H_
 
-#include <rpcs.h>
+#include "rpcs.h"
 
 class ppsocket;
 

--- a/lib/siscomponentrecord.h
+++ b/lib/siscomponentrecord.h
@@ -20,7 +20,7 @@
 #ifndef _SISCOMPONENTRECORD_H
 #define _SISCOMPONENTRECORD_H
 
-#include <sistypes.h>
+#include "sistypes.h"
 
 class SISFile;
 

--- a/lib/sisfile.h
+++ b/lib/sisfile.h
@@ -20,9 +20,9 @@
 #ifndef _SISFILE_H
 #define _SISFILE_H
 
-#include <sistypes.h>
-#include <sisfileheader.h>
-#include <siscomponentrecord.h>
+#include "sistypes.h"
+#include "sisfileheader.h"
+#include "siscomponentrecord.h"
 
 class SISLangRecord;
 class SISFileRecord;

--- a/lib/sisfileheader.h
+++ b/lib/sisfileheader.h
@@ -20,7 +20,7 @@
 #ifndef _SISFILEHEADER_H
 #define _SISFILEHEADER_H
 
-#include <sistypes.h>
+#include "sistypes.h"
 
 /**
  * The first part of a SISFile.

--- a/lib/sisfilerecord.h
+++ b/lib/sisfilerecord.h
@@ -20,7 +20,7 @@
 #ifndef _SISFILERECORD_H
 #define _SISFILERECORD_H
 
-#include <sistypes.h>
+#include "sistypes.h"
 
 class SISFile;
 

--- a/lib/sislangrecord.h
+++ b/lib/sislangrecord.h
@@ -20,7 +20,7 @@
 #ifndef _SISLANGRECORD_H
 #define _SISLANGRECORD_H
 
-#include <sistypes.h>
+#include "sistypes.h"
 
 /**
  * A simple language record, only containing the epoc specific 16 bit

--- a/lib/sisreqrecord.h
+++ b/lib/sisreqrecord.h
@@ -20,7 +20,7 @@
 #ifndef _SISREQRECORD_H
 #define _SISREQRECORD_H
 
-#include <sistypes.h>
+#include "sistypes.h"
 
 class SISFile;
 

--- a/lib/wprt.h
+++ b/lib/wprt.h
@@ -20,8 +20,8 @@
 #ifndef _WPRT_H_
 #define _WPRT_H_
 
-#include <rfsv.h>
-#include <Enum.h>
+#include "rfsv.h"
+#include "Enum.h"
 
 class ppsocket;
 class bufferStore;

--- a/ncpd/link.cc
+++ b/ncpd/link.cc
@@ -22,14 +22,14 @@
 
 #include <iostream>
 
-#include <bufferstore.h>
-#include <bufferarray.h>
-
 #include <stdint.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <stdio.h>
 #include <sys/time.h>
+
+#include "bufferstore.h"
+#include "bufferarray.h"
 
 #include "link.h"
 #include "packet.h"

--- a/ncpd/linkchan.cc
+++ b/ncpd/linkchan.cc
@@ -24,8 +24,8 @@
 #include <string>
 #include <cstring>
 
-#include <bufferstore.h>
-#include <bufferarray.h>
+#include "bufferstore.h"
+#include "bufferarray.h"
 
 #include "linkchan.h"
 #include "ncp.h"

--- a/ncpd/linkchan.h
+++ b/ncpd/linkchan.h
@@ -22,7 +22,7 @@
 #define _linkchan_h_
 
 #include "channel.h"
-#include <bufferarray.h>
+#include "bufferarray.h"
 
 #define LINKCHAN_DEBUG_LOG  1
 #define LINKCHAN_DEBUG_DUMP 2

--- a/ncpd/ncp.cc
+++ b/ncpd/ncp.cc
@@ -25,10 +25,10 @@
 
 #include <time.h>
 
-#include <bufferstore.h>
-#include <bufferarray.h>
-#include <rfsv.h>
+#include "bufferstore.h"
+#include "bufferarray.h"
 
+#include "rfsv.h"
 #include "ncp.h"
 #include "linkchan.h"
 #include "link.h"
@@ -132,11 +132,11 @@ receive(bufferStore s) {
 	} else {
 	    int allData = s.getByte(1);
 	    s.discardFirstBytes(2);
-            
+
             if (protocolVersion == PV_SERIES_3) {
                 channel = lastSentChannel;
             }
-                
+
 	    if (!isValidChannel(channel)) {
 		lerr << "ncp: Got message for unknown channel\n";
 	    } else {

--- a/ncpd/socketchan.cc
+++ b/ncpd/socketchan.cc
@@ -22,12 +22,11 @@
 
 #include <string>
 
-#include <ppsocket.h>
-#include <rfsv.h>
-
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "ppsocket.h"
+#include "rfsv.h"
 #include "socketchan.h"
 #include "ncp.h"
 #include "main.h"


### PR DESCRIPTION
This change switches to using local quoted includes for files in the plptools project. It's motivated the rather more strict requirements of the Swift Package Manager which I use for Reconnect, but it feels like good practice and will hopefully make it easier for others who wish to treat plptools as a source dependency. I think it also helps us prepare for a potential libplp if we ever choose to go there.

I think there's a little nuance in terms of local vs system when you start to look at something like ncpd as the boundary isn't 100% clear to me there, but as a first-pass, I'm treating everything in the plptools source tree as 'local'.