### PR TITLE
fix: Consistent documented parameter naming

### DIFF
--- a/lib/rpcs.h
+++ b/lib/rpcs.h
@@ -227,7 +227,7 @@ public:
     *
     * @returns A psion error code. 0 = Ok.
     */
-    Enum<rfsv::errs> stopProgram(const char *);
+    Enum<rfsv::errs> stopProgram(const char *program);
 
     Enum<rfsv::errs> queryProgram(const char *);
 
@@ -271,7 +271,7 @@ public:
     *
     * @returns A psion error code. 0 = Ok.
     */
-    Enum<rfsv::errs> getOwnerInfo(bufferArray &);
+    Enum<rfsv::errs> getOwnerInfo(bufferArray &owner);
 
     /**
     * Retrieves the type of machine on the remote side
@@ -351,7 +351,7 @@ public:
     *
     * @returns Psion error code. 0 = Ok.
     */
-    virtual Enum<rfsv::errs> getMachineInfo(machineInfo &) { return rfsv::E_PSI_NOT_SIBO;}
+    virtual Enum<rfsv::errs> getMachineInfo(machineInfo &machineInfo) { return rfsv::E_PSI_NOT_SIBO;}
 
     /**
      * Release an rpcs handle.

--- a/ncpd/link.h
+++ b/ncpd/link.h
@@ -80,7 +80,7 @@ public:
      * @param ncp   The calling ncp instance.
      * @_verbose    Verbosity (for debugging/troubleshooting)
      */
-    Link(const char *fname, int baud, ncp *_ncp, unsigned short _verbose = 0);
+    Link(const char *fname, int baud, ncp *ncp, unsigned short _verbose = 0);
 
     /**
      * Disconnects from device and destroys instance.


### PR DESCRIPTION
There are a few parameters documented in 'rpcs.h' and 'link.h' where the documented names don't match the parameter names (or they're just omitted). This change addresses that.