### PR TITLE
fix: Calculate timestamps correctly for timezones with negative offsets

### DIFF
--- a/lib/bufferstore.cc
+++ b/lib/bufferstore.cc
@@ -110,6 +110,13 @@ uint32_t bufferStore::getDWord(long pos) const {
 	(buff[pos+start+3] << 24);
 }
 
+int32_t bufferStore::getSDWord(long pos) const {
+    return buff[pos+start] +
+        (buff[pos+start+1] << 8) +
+        (buff[pos+start+2] << 16) +
+        (buff[pos+start+3] << 24);
+}
+
 const char * bufferStore::getString(long pos) const {
     return (const char *)buff + pos + start;
 }

--- a/lib/bufferstore.h
+++ b/lib/bufferstore.h
@@ -103,6 +103,15 @@ public:
     uint32_t getDWord(long pos = 0) const;
 
     /**
+     * Retrieves the signed dword at index <em>pos</em>.
+     *
+     * @param pos The index of the signed dword  to retrieve.
+     *
+     * @returns The value of the signed dword at index <em>pos</em>
+     */
+    int32_t getSDWord(long pos = 0) const;
+
+    /**
     * Retrieves the characters at index <em>pos</em>.
     *
     * @param pos The index of the characters to retrieve.

--- a/lib/rpcs32.cc
+++ b/lib/rpcs32.cc
@@ -93,7 +93,7 @@ getMachineInfo(machineInfo &mi)
     mi.time.tv_low = a.getDWord(48);
     mi.time.tv_high = a.getDWord(52);
 
-    mi.tz.utc_offset = a.getDWord(60);
+    mi.tz.utc_offset = a.getSDWord(60);
     mi.tz.dst_zones = a.getDWord(64);
     mi.tz.home_zone = a.getDWord(68);
 


### PR DESCRIPTION
This change ensures we correctly treat the timezone offset as a signed 32-bit integer, fixing timestamp calculations for devices in timezones with negative UTC offsets.